### PR TITLE
Enable frontend image uploads for e-commerce

### DIFF
--- a/store/forms.py
+++ b/store/forms.py
@@ -1,0 +1,25 @@
+from django import forms
+from .models import Product
+
+
+class ProductForm(forms.ModelForm):
+    class Meta:
+        model = Product
+        fields = [
+            "name",
+            "description",
+            "price",
+            "discount",
+            "category",
+            "is_new",
+            "image",
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field_name, field in self.fields.items():
+            css_classes = field.widget.attrs.get("class", "")
+            field.widget.attrs["class"] = (css_classes + " form-control").strip()
+        # File input needs proper class
+        self.fields["image"].widget.attrs["class"] = "form-control-file"
+

--- a/store/templates/store/product_form.html
+++ b/store/templates/store/product_form.html
@@ -1,0 +1,29 @@
+{% extends 'store/base.html' %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>{{ title }}</h2>
+
+    {% if messages %}
+        {% for message in messages %}
+            <div class="alert alert-{{ message.tags }}">{{ message }}</div>
+        {% endfor %}
+    {% endif %}
+
+    <form method="post" enctype="multipart/form-data" class="mt-3">
+        {% csrf_token %}
+
+        {% if image_only %}
+            <div class="mb-3">
+                <label class="form-label">Image</label>
+                {{ form.image }}
+            </div>
+        {% else %}
+            {{ form.as_p }}
+        {% endif %}
+
+        <button type="submit" class="btn btn-primary">{{ submit_label }}</button>
+    </form>
+</div>
+{% endblock %}
+

--- a/store/urls.py
+++ b/store/urls.py
@@ -43,5 +43,9 @@ urlpatterns = [
     
     # Order Confirmation
     path('order/confirmation/<int:order_id>/', views.order_confirmation_view, name='order_confirmation'),
+
+    # Product management (frontend)
+    path('products/create/', views.product_create, name='product_create'),
+    path('products/<int:product_id>/image/', views.product_update_image, name='product_update_image'),
 ]
 


### PR DESCRIPTION
Add frontend product creation and image upload functionality to bypass the admin panel.

---
<a href="https://cursor.com/background-agent?bcId=bc-a704eba9-7963-44cf-9a58-70786facce1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a704eba9-7963-44cf-9a58-70786facce1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

